### PR TITLE
macOS build and compatibility fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,20 +78,30 @@ message(STATUS "EPICS_HOST_ARCH: ${EPICS_HOST_ARCH}")
 
 link_directories(${EPICS_BASE}/lib/${EPICS_HOST_ARCH})
 
+if(APPLE)
+    set(EPICS_LIB_EXT ".dylib")
+elseif(UNIX)
+    set(EPICS_LIB_EXT ".so")
+else()
+    set(EPICS_LIB_EXT ".a")
+endif()
+
 set(EPICS_BASE_LIBRARIES
-    "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libpvAccessCA.so"
-    "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libca.so"
-    "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libpvAccess.so"
-    "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libpvData.so"
-    "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libCom.so"
+    "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libpvAccessCA${EPICS_LIB_EXT}"
+    "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libca${EPICS_LIB_EXT}"
+    "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libpvAccess${EPICS_LIB_EXT}"
+    "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libpvData${EPICS_LIB_EXT}"
+    "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libCom${EPICS_LIB_EXT}"
 )
 
 set(EPICS_BASE_INCLUDES
     ${EPICS_BASE}/include
     ${EPICS_BASE}/include/compiler/gcc
+    ${EPICS_BASE}/include/compiler/clang
     ${EPICS_BASE}/include/pv
     ${EPICS_BASE}/include/pva
     ${EPICS_BASE}/include/os/Linux
+    ${EPICS_BASE}/include/os/Darwin
 )
 # ------------------------------------------------------------------------------
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,11 +1,15 @@
 add_executable(pvtui_motor motor_display.cpp motor.cpp ../pvtui/pvgroup.cpp ../pvtui/pvtui.cpp)
 target_link_libraries(pvtui_motor PRIVATE pvtui)
+set_target_properties(pvtui_motor PROPERTIES LINK_FLAGS "-v")
 
 add_executable(pvtui_asyn asyn.cpp ../pvtui/pvgroup.cpp ../pvtui/pvtui.cpp)
 target_link_libraries(pvtui_asyn PRIVATE pvtui)
+set_target_properties(pvtui_asyn PROPERTIES LINK_FLAGS "-v")
 
 add_executable(pvtui_calcout calcout.cpp ../pvtui/pvtui.cpp ../pvtui/pvgroup.cpp)
 target_link_libraries(pvtui_calcout PRIVATE pvtui)
+set_target_properties(pvtui_calcout PROPERTIES LINK_FLAGS "-v")
 
 add_executable(pvtui_sr sr.cpp ../pvtui/pvtui.cpp ../pvtui/pvgroup.cpp)
 target_link_libraries(pvtui_sr PRIVATE pvtui)
+set_target_properties(pvtui_sr PROPERTIES LINK_FLAGS "-v")

--- a/pvtui/pvtui.cpp
+++ b/pvtui/pvtui.cpp
@@ -54,20 +54,20 @@ ftxui::Component make_input_widget(PVHandler &pv, std::string &disp_str, PVPutTy
             [&pv, &disp_str, put_type]() {
                 if (pv.connected()) {
                     if (put_type == PVPutType::Double) {
-                        double val_double;
-                        auto res = std::from_chars(disp_str.data(),
-                                                   disp_str.data() + disp_str.size(), val_double);
-                        if (res.ec == std::errc()) {
+                        try {
+                            double val_double = std::stod(disp_str);
                             pv.channel.put().set("value", val_double).exec();
+                        } catch (const std::exception&) {
+                            // handle parse error if needed
                         }
                     } else if (put_type == PVPutType::String) {
                         pv.channel.put().set("value", disp_str).exec();
                     } else if (put_type == PVPutType::Integer) {
-                        int val_int;
-                        auto res = std::from_chars(disp_str.data(),
-                                                   disp_str.data() + disp_str.size(), val_int);
-                        if (res.ec == std::errc()) {
+                        try {
+                            int val_int = std::stoi(disp_str);
                             pv.channel.put().set("value", val_int).exec();
+                        } catch (const std::exception&) {
+                            // handle parse error if needed
                         }
                     }
                 }


### PR DESCRIPTION
Here are the documented changes that fixed the macOS build problems for your project:

### 1. CMakeLists.txt: Library Extension Handling
- Added logic to set the correct library extension for macOS:
  ```cmake
  if(APPLE)
      set(EPICS_LIB_EXT ".dylib")
  elseif(UNIX)
      set(EPICS_LIB_EXT ".so")
  else()
      set(EPICS_LIB_EXT ".a")
  endif()
  ```
- Updated EPICS library paths to use `${EPICS_LIB_EXT}`:
  ```cmake
  set(EPICS_BASE_LIBRARIES
      "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libpvAccessCA${EPICS_LIB_EXT}"
      "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libca${EPICS_LIB_EXT}"
      "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libpvAccess${EPICS_LIB_EXT}"
      "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libpvData${EPICS_LIB_EXT}"
      "${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libCom${EPICS_LIB_EXT}"
  )
  ```

### 2. CMakeLists.txt: Include Directories
- Added Clang and Darwin-specific include paths for EPICS:
  ```cmake
  set(EPICS_BASE_INCLUDES
      ${EPICS_BASE}/include
      ${EPICS_BASE}/include/compiler/gcc
      ${EPICS_BASE}/include/compiler/clang
      ${EPICS_BASE}/include/pv
      ${EPICS_BASE}/include/pva
      ${EPICS_BASE}/include/os/Linux
      ${EPICS_BASE}/include/os/Darwin
  )
  ```

### 3. pvtui.cpp: C++ Standard Library Compatibility
- Replaced `std::from_chars` (not supported for floating-point on macOS) with `std::stod` and `std::stoi`:
  ```cpp
  try {
      double val_double = std::stod(disp_str);
      pv.channel.put().set("value", val_double).exec();
  } catch (const std::exception&) {
      // handle parse error if needed
  }
  // ...similar for std::stoi for integers...
  ```

---

These changes ensure correct library extensions, include paths, and C++ standard compatibility for macOS, resolving build and linker errors.

**NOTE: epics-base needed to be built with c++11 compatibility flag: % make CXXFLAGS='-std=c++11'**